### PR TITLE
Allow passing additional args to the constructor of class Namespace

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -138,8 +138,10 @@ Define different namespaces on a single socket. ::
 
     class ChatNamespace(BaseNamespace):
 
+        def __init__(self, io, path, id):
+            self.id = id
         def on_aaa_response(self, *args):
-            print('on_aaa_response', args)
+            print(self.id + ': on_aaa_response', args)
 
     class NewsNamespace(BaseNamespace):
 
@@ -147,7 +149,7 @@ Define different namespaces on a single socket. ::
             print('on_aaa_response', args)
 
     socketIO = SocketIO('localhost', 8000)
-    chat_namespace = socketIO.define(ChatNamespace, '/chat')
+    chat_namespace = socketIO.define(ChatNamespace, '/chat', 'myId')
     news_namespace = socketIO.define(NewsNamespace, '/news')
 
     chat_namespace.emit('aaa')

--- a/socketIO_client_nexus/__init__.py
+++ b/socketIO_client_nexus/__init__.py
@@ -374,8 +374,8 @@ class SocketIO(EngineIO):
 
     # Define
 
-    def define(self, Namespace, path=''):
-        self._namespace_by_path[path] = namespace = Namespace(self, path)
+    def define(self, Namespace, path='', *args):
+        self._namespace_by_path[path] = namespace = Namespace(self, path, *args)
         if path:
             self.connect(path)
             self.wait(for_namespace=namespace)


### PR DESCRIPTION
This PR adds the ability to pass extra args to the constructor of class Namespace through method SocketIO.define:

```
class MyNamespace(BaseNamespace):
    def __init__(self, socket, path, myid):
        self.myid = myid

socket = SocketIO(server, port)
ns = socket.define(MyNamespace, '/path', 'myid')

```